### PR TITLE
Fix typo to correspond to #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4427,7 +4427,7 @@ export const Upload = () => {
 ```TSX
 // src/pages/Login/index.tsxを作成
 import { Button, Card, TextField, Typography } from "@material-ui/core";
-import { Logo } from "../../compoennts/Logo";
+import { Logo } from "../../components/Logo";
 import useStyles from "./style";
 export const Login = () => {
   const styles = useStyles();
@@ -4618,7 +4618,7 @@ export default makeStyles({
 // index.tsxのコード
 
 import { Button, Card, TextField, Typography } from "@material-ui/core";
-import { Logo } from "../../compoennts/Logo";
+import { Logo } from "../../components/Logo";
 import useStyles from "./style";
 
 export const Signup = () => {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, TextField, Typography } from "@material-ui/core";
-import { Logo } from "../../compoennts/Logo";
+import { Logo } from "../../components/Logo";
 import useStyles from "./style";
 export const Login = () => {
   const styles = useStyles();

--- a/src/pages/Signup/index.tsx
+++ b/src/pages/Signup/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, TextField, Typography } from "@material-ui/core";
-import { Logo } from "../../compoennts/Logo";
+import { Logo } from "../../components/Logo";
 import useStyles from "./style";
 
 export const Signup = () => {


### PR DESCRIPTION
[認証画面のデザイン作成](https://github.com/Hiro-mackay/react-bootcamp/tree/bootcamp-2#%E8%AA%8D%E8%A8%BC%E7%94%BB%E9%9D%A2%E3%81%AE%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3%E4%BD%9C%E6%88%90) の確認用コードが動かなくなっていたので、 #3 の修正をこちらにも反映させて頂きました。
ご確認お願いいたします。